### PR TITLE
Fix mem leaks

### DIFF
--- a/pyorient_native/listener.cpp
+++ b/pyorient_native/listener.cpp
@@ -399,4 +399,5 @@ TrackerListener::~TrackerListener() {
   while ( !this->obj_stack.empty() ){
     this->obj_stack.pop();
   }
+  delete this->cur_field;
 }

--- a/pyorient_native/orientc_reader.cpp
+++ b/pyorient_native/orientc_reader.cpp
@@ -11,12 +11,19 @@ char* PyString_AsString(PyObject* obj){
   if(obj==NULL)
     return "";
   if (PyUnicode_Check(obj)) {
+    char* rv;
     PyObject * byte_obj = PyUnicode_AsEncodedString(obj, "ASCII", "strict");
-    return PyBytes_AsString(byte_obj);
+    rv = PyBytes_AsString(byte_obj);
+    Py_XDECREF(byte_obj);
+    return rv;
   } else if (PyBytes_Check(obj)) {
     return PyBytes_AsString(obj);
   } else {
-    return PyString_AsString(PyObject_Str(obj));
+    char* rv;
+    PyObject* byte_obj = PyObject_Str(obj);
+    rv = PyString_AsString(byte_obj);
+    Py_XDECREF(byte_obj);
+    return rv;
   }
 }
 #endif


### PR DESCRIPTION
This fixes two leaks.

TrackerListener - a new C++ string is allocated in the constructor. Other methods free this string and replace it with another newly allocated string. But when the TrackerListener is deconstructed that string is left hanging. This causes a slow leak over a long period of time.

PyString_AsString (py3) - some of the logic paths in this function end up returning a new reference, some do not. The py2 PyString_AsString this function replaces does not return a new reference, so this function should not either. This causes memory usage to increase rather quickly.