### PR TITLE
check whether to convert to int or long in python3

### DIFF
--- a/pyorient_native/encoder.cpp
+++ b/pyorient_native/encoder.cpp
@@ -125,9 +125,6 @@ void PyRecWriter::write_dict(PyObject* pydict){
 }
 
 void PyRecWriter::write_int(PyObject* pyval){
-  // TODO: Python >= 2.7 does not distinguish bet int and long by default
-    //       BitLength should be used to figure out whether call write_int
-    //       or write_long
   int val = (int) PyInt_AsLong(pyval);
   if (val == -1 && PyErr_Occurred()!=NULL){
     PyObject *temp = PyObject_GetAttrString(pyval,"__class__");

--- a/pyorient_native/orientc_reader.h
+++ b/pyorient_native/orientc_reader.h
@@ -14,7 +14,7 @@
 #if PY_MAJOR_VERSION >= 3
 #define PyInt_FromLong PyLong_FromLong
 #define PyInt_AsLong PyLong_AsLong
-#define PyInt_Check PyLong_Check
+#define PyInt_Check(val) PyLong_Check(val) && ((int) PyInt_AsLong(val)) == ((long) PyInt_AsLong(val))
 #define PyString_Check PyUnicode_Check
 char* PyString_AsString(PyObject* obj);
 #endif


### PR DESCRIPTION
Check whether type is int or long by looking for overflow error.
I just changed the PyIntCheck to make sure that converting to 'int' won't change the value.